### PR TITLE
Add better heuristic for relative imports

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -78,12 +78,12 @@ Target.create "YarnInstall" <| fun _ ->
 Target.create "Prepare" ignore
 
 Target.create "BuildOnly" <| fun _ ->
-  dotnetExec "fable" $"{srcDir} --sourceMaps --run webpack"
+  dotnetExec "fable" $"{srcDir} --sourceMaps --run webpack --mode=production"
 
 Target.create "Build" ignore
 
 Target.create "Watch" <| fun _ ->
-  dotnetExec "fable" $"watch {srcDir} --sourceMaps --define DEBUG --run webpack -w"
+  dotnetExec "fable" $"watch {srcDir} --sourceMaps --define DEBUG --run webpack -w --mode=development"
 
 "Clean"
   ==> "YarnInstall"
@@ -105,6 +105,12 @@ module Test =
     let testDir = testDir </> "jsoo"
     let outputDir = outputDir </> "test_jsoo"
     let srcDir = testDir </> "src"
+
+    let clean () =
+      !! $"{outputDir}/*"
+      ++ $"{srcDir}/*.mli"
+      ++ $"{srcDir}/stub.js"
+      |> Seq.iter Shell.rm
 
     let generateBindings () =
       Directory.create outputDir
@@ -139,11 +145,13 @@ module Test =
         printfn "* copied to %s" file
       inDirectory testDir <| fun () -> dune "build"
 
+Target.create "TestJsooClean" <| fun _ -> Test.Jsoo.clean ()
 Target.create "TestJsooGenerateBindings" <| fun _ -> Test.Jsoo.generateBindings ()
 Target.create "TestJsooBuild" <| fun _ -> Test.Jsoo.build ()
 Target.create "TestJsoo" ignore
 
 "BuildOnly"
+  ==> "TestJsooClean"
   ==> "TestJsooGenerateBindings"
   ==> "TestJsooBuild"
   ==> "TestJsoo"

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,6 +15,7 @@ Modules with **\[\<AutoOpen\>\]** does not require `open` to use.
   - `Common.fs` ... **\[\<AutoOpen\>\]** global command line options, types, and modules
   - `Syntax.fs` ... AST for parsed TypeScAript code
   - `Naming.fs` ... naming helpers
+  - `JsHelper.fs` ... helper functions for JavaScript-related things e.g. NPM packages and ES6 module names.
   - `Typer.fs`  ... functions for resolving and manipulating AST
   - `Parser.fs` ... functions for converting TS syntax tree to our AST
   - `Target.fs` ... generic definitions for each targets (`ITarget<_>`)
@@ -46,6 +47,12 @@ Modules with **\[\<AutoOpen\>\]** does not require `open` to use.
 
 - Node 14.0 or higher
   - [yarn](https://yarnpkg.com/) is required.
+
+## Debugging
+
+`dotnet fake build -t Watch` to live update `dist/ts2ocaml.js`.
+
+It will be bundled by Webpack with the `development` mode.
 
 ## Building
 

--- a/src/Extensions.fs
+++ b/src/Extensions.fs
@@ -51,6 +51,10 @@ module String =
       state.Replace(e, "\\" + e)
     ) s
 
+module Result =
+  let toOption result =
+    match result with Ok x -> Some x | Error _ -> None
+
 module List =
   let splitChoice2 (xs: Choice<'t1, 't2> list) : 't1 list * 't2 list =
     let xs1, xs2 =
@@ -111,6 +115,31 @@ module JS =
       else
         value
     ))
+
+type JS.ObjectConstructor with
+  [<Emit("$0.entries($1)")>]
+  member __.entries (x: 'a) : (string * obj) [] = jsNative
+
+module Path =
+  module Node = Node.Api
+
+  type Absolute = string
+  /// relative to current directory
+  type Relative = string
+  type Difference = string
+
+  let relative (path: string) : Relative =
+    Node.path.relative(Node.``process``.cwd(), path)
+
+  let absolute (path: string) : Absolute =
+    if Node.path.isAbsolute(path) then path
+    else Node.path.resolve(path)
+
+  let diff (fromPath: string) (toPath: string) : Difference =
+    let fromPath =
+      if Node.fs.lstatSync(!^fromPath).isDirectory() then fromPath
+      else Node.path.dirname(fromPath)
+    Node.path.relative(fromPath, toPath)
 
 open Yargs
 

--- a/src/JsHelper.fs
+++ b/src/JsHelper.fs
@@ -1,0 +1,210 @@
+module JsHelper
+open Fable.Core
+open Fable.Core.JsInterop
+
+module Node = Node.Api
+
+let getPackageJsonPath (exampleFilePath: string) =
+  let parts =
+    exampleFilePath
+    |> String.split Node.path.sep
+    |> List.ofArray
+  match parts |> List.tryFindIndexBack ((=) "node_modules") with
+  | None -> None
+  | Some i ->
+    let prefix, rest = List.splitAt (i+1) parts
+    if rest = [] then None
+    else
+      let packageName =
+        match rest with
+        | userName :: packageName :: _ when userName.StartsWith("@") -> [userName; packageName]
+        | packageName :: _ -> [packageName]
+        | _ -> failwith "impossible_getPackageJsonPath_root"
+      let path =
+        prefix @ packageName @ ["package.json"] |> String.concat Node.path.sep
+
+      if not <| Node.fs.existsSync(!^path) then None
+      else if Node.path.isAbsolute(path) then Some path
+      else Some (Node.path.resolve(path))
+
+type IPackageExportItem =
+  [<EmitIndexer>]
+  abstract Item: string -> string with get
+
+type IPackageJson =
+  abstract name: string
+  abstract version: string
+  abstract types: string option
+  abstract typings: string option
+  abstract exports: obj option
+
+let getPackageJson (path: string) : IPackageJson =
+  let content = Node.fs.readFileSync(path, "utf-8")
+  !!JS.JSON.parse(content)
+
+let getPackageInfo (exampleFilePath: string) : Syntax.PackageInfo option =
+  match getPackageJsonPath exampleFilePath with
+  | None -> None
+  | Some path ->
+    let p = getPackageJson path
+
+    let rootPath = Node.path.dirname(path)
+
+    let name =
+      if p.name.StartsWith("@types/") then
+        let tmp = p.name.Substring(7)
+        if tmp.Contains("__") then "@" + tmp.Replace("__", "/")
+        else tmp
+      else p.name
+
+    let shortName =
+      p.name
+      |> String.splitThenRemoveEmptyEntries "/"
+      |> Array.skipWhile (fun s -> s.StartsWith("@"))
+      |> String.concat "/"
+
+    let exports =
+      match p.exports with
+      | None -> []
+      | Some exports ->
+        [ for k, v in JS.Constructors.Object.entries exports do
+            if isIn "types" v then yield k, v?types ]
+
+    let indexFile =
+      match Option.orElse p.types p.typings, exports |> List.tryFind (fst >> (=) ".") with
+      | None, None ->
+        let index = Node.path.join(rootPath, "index.d.ts")
+        if not <| Node.fs.existsSync(!^index) then None
+        else
+          Node.path.relative(Node.``process``.cwd(), index) |> Node.path.normalize |> Some
+      | Some typings, _
+      | None, Some (_, typings) ->
+        Node.path.relative(Node.``process``.cwd(), Node.path.join(rootPath, typings)) |> Node.path.normalize |> Some
+
+    let exports =
+      exports
+      |> List.filter (fst >> (<>) ".")
+      |> List.map (fun (k, v) ->
+        {| submodule = k;
+           file = Node.path.relative(Node.``process``.cwd(), Node.path.join(rootPath, v)) |> Node.path.normalize |})
+
+    Some {
+      name = name
+      shortName = shortName
+      isDefinitelyTyped = p.name.StartsWith("@types/")
+      version = p.version
+      rootPath = rootPath
+      indexFile = indexFile
+      exports = exports
+    }
+
+type InferenceResult =
+  | Valid of string
+  | Heuristic of string
+  | Unknown
+module InferenceResult =
+  let unwrap defaultValue = function
+    | Valid s | Heuristic s -> s
+    | Unknown -> defaultValue
+
+let inferPackageInfoFromFileName (sourceFile: Path.Relative) : {| name: string; isDefinitelyTyped: bool; rest: string list |} option =
+  let parts =
+    sourceFile
+      |> fun x ->
+        let inm = x.LastIndexOf "node_modules"
+        if inm = -1 then x
+        else x.Substring(inm+13)
+      |> String.split "/"
+      |> List.ofArray
+  match parts with
+  | [] -> None
+  | "@types" :: name :: rest ->
+    let name = if name.Contains("__") then "@" + name.Replace("__", "/") else name
+    Some {| name = name; isDefinitelyTyped = true; rest = rest |}
+  | user :: name :: rest when user.StartsWith("@") ->
+    Some {| name = user + "/" + name; isDefinitelyTyped = true; rest = rest |}
+  | name :: rest ->
+    Some {| name = name; isDefinitelyTyped = true; rest = rest |}
+
+let inline stripExtension path =
+  path |> String.replace ".ts" "" |> String.replace ".d" ""
+
+let getJsModuleName (info: Syntax.PackageInfo option) (sourceFile: Path.Relative) =
+  let getSubmodule rest =
+    match List.rev rest with
+    | "index.d.ts" :: name :: _ -> name
+    | name :: _ -> stripExtension name
+    | [] -> failwith "impossible"
+  match info with
+  | Some info ->
+    if info.indexFile |> Option.exists ((=) sourceFile) then
+      info.name |> Valid
+    else
+      // make it relative to the package root directory
+      let relativePath = Path.diff info.rootPath (Path.absolute sourceFile)
+      if info.isDefinitelyTyped then
+        Node.path.join(info.name, stripExtension relativePath) |> Valid
+      else
+        match info.exports |> List.tryFind (fun x -> x.file = sourceFile) with
+        | Some export -> Node.path.join(info.name, export.submodule) |> Valid
+        | None -> // heuristic
+          let submodule =
+            relativePath
+            |> String.splitThenRemoveEmptyEntries "/"
+            |> List.ofArray
+            |> getSubmodule
+          Node.path.join(info.name, submodule) |> Heuristic
+  | None ->
+    match inferPackageInfoFromFileName sourceFile with
+    | None -> Unknown
+    | Some info ->
+      if info.isDefinitelyTyped then
+        let rest =
+          match List.rev info.rest with
+          | "index.d.ts" :: rest -> List.rev rest
+          | other :: rest ->
+            stripExtension other :: rest |> List.rev
+          | [] -> []
+        info.name :: rest |> String.concat "/" |> Valid
+      else
+        match info.rest with
+        | ["index.d.ts"] -> Valid info.name
+        | rest ->
+          info.name + "/" + getSubmodule rest
+          |> Heuristic
+
+let deriveModuleName (info: Syntax.PackageInfo option) (srcs: Path.Relative list) =
+ match srcs with
+  | [] -> failwith "impossible_deriveModuleName"
+  | [src] -> getJsModuleName info src
+  | srcs ->
+    let names =
+      srcs
+      |> List.choose inferPackageInfoFromFileName
+      |> List.map (fun info -> info.name)
+      |> List.groupBy id
+      |> List.map (fun (name, xs) -> name, List.length xs)
+    names |> List.maxBy (fun (_, count) -> count) |> fst |> Heuristic
+
+let deriveOutputFileName
+  (opts: #GlobalOptions) (info: Syntax.PackageInfo option) (srcs: Path.Relative list)
+  (moduleNameToFileName: string -> string) (whenUnknown: string) =
+  let inline log x =
+    Log.tracef opts "* the inferred output file name is '%s'" x
+    x
+  match deriveModuleName info srcs with
+  | Valid moduleName -> moduleNameToFileName moduleName |> log
+  | Heuristic best -> moduleNameToFileName best |> log
+  | Unknown ->
+    Log.warnf opts "* the output file name cannot be inferred. '%s' is used instead." whenUnknown
+    whenUnknown
+
+let resolveRelativeImportPath (info: Syntax.PackageInfo option) (currentFile: Path.Relative) (path: string) =
+  if path.StartsWith(".") then
+    let targetPath =
+      let path = Node.path.join(Node.path.dirname(currentFile), path)
+      if not <| path.EndsWith(".ts") then Node.path.join(path, "index.d.ts")
+      else path
+    getJsModuleName info targetPath
+  else
+    Valid path

--- a/src/Naming.fs
+++ b/src/Naming.fs
@@ -152,34 +152,3 @@ let removeQuotesAndTrim (s: string) =
     if (c = '\"' || c = ''')
     then s.Trim(c).Trim()
     else s.Trim()
-
-// gets the JavaScript module name
-// intended for use by SourceFile.fileName which has slashes normalized
-// TODO implement all of https://github.com/ajafff/tsutils/issues/14#issuecomment-345544684
-let getJsModuleName (path: string): string =
-  let parts =
-    path
-      |> fun x ->
-        let inm = path.LastIndexOf "node_modules"
-        if inm = -1 then x
-        else x.Substring(inm+13)
-      |> fun x ->
-        let is = x.LastIndexOf "@"
-        if is = -1 then x
-        else x.Substring(is)
-      |> fun x ->
-        x.Split '/'
-          |> List.ofArray
-          |> List.filter (fun s -> s <> "index.d.ts" && s <> "types")
-
-  let out =
-    match parts with
-      | "@types"::x::xs ->
-        let xs' = x.Replace("__", "/") :: xs
-        String.Join("/", xs')
-      | x::xs when x.StartsWith "@" ->
-        String.Join("/", x :: xs)
-      // TODO: Shouldn't this be List.last instead?
-      | xs -> List.head xs
-  out.Replace(".ts","").Replace(".d","")
-

--- a/src/Syntax.fs
+++ b/src/Syntax.fs
@@ -518,11 +518,31 @@ and Reference =
   | LibReference of string
 
 and SourceFile = {
-  fileName: string
+  fileName: Path.Relative
   statements: Statement list
   references: Reference list
   hasNoDefaultLib: bool
   moduleName: string option
+}
+
+type PackageInfo = {
+  /// * will be `foo` if `fullName` is `@types/foo`
+  /// * will be `@user/foo` if `fullName` is `@user/foo`
+  name: string
+  /// * will be `foo` if `fullName` is `@user/foo`
+  shortName: string
+  isDefinitelyTyped: bool
+  version: string
+  /// absolute path
+  rootPath: Path.Absolute
+  /// `index.d.ts` or the one specified in `package.json`.
+  indexFile: Path.Relative option
+  exports: {| submodule: string; file: Path.Relative |} list
+}
+
+type Input = {
+  sources: SourceFile list
+  info: PackageInfo option
 }
 
 module Literal =

--- a/src/Target.fs
+++ b/src/Target.fs
@@ -7,12 +7,12 @@ type ITarget<'Options when 'Options :> GlobalOptions> =
   abstract Command: string
   abstract Description: string
   abstract Builder: (Argv<'Options> -> Argv<'Options>)
-  abstract Run: sources:SourceFile list * options:'Options -> unit
+  abstract Run: input: Input * options:'Options -> unit
 
 open Fable.Core
 open Fable.Core.JsInterop
 
-let register (parse: GlobalOptions -> string[] -> SourceFile list) (target: ITarget<'TargetOptions>) (argv: Argv<'Options>) : Argv<'Options>
+let register (parse: GlobalOptions -> string[] -> Input) (target: ITarget<'TargetOptions>) (argv: Argv<'Options>) : Argv<'Options>
   when 'Options :> GlobalOptions
   and  'TargetOptions :> GlobalOptions =
   argv.command(
@@ -23,9 +23,9 @@ let register (parse: GlobalOptions -> string[] -> SourceFile list) (target: ITar
     ),
     handler = (fun (argv: Arguments<'Options>) ->
       let inputs = argv.["inputs"] :?> string[]
-      let srcs = parse !!argv.Options inputs
       try
-        target.Run(srcs, !!argv.Options)
+        let input = parse !!argv.Options inputs
+        target.Run(input, !!argv.Options)
       with
         e ->
           eprintfn "%s" e.StackTrace

--- a/src/Targets/JsOfOCaml/OCamlHelper.fs
+++ b/src/Targets/JsOfOCaml/OCamlHelper.fs
@@ -366,22 +366,20 @@ module Naming =
       else sprintf "%s_%d" name arity
     | None -> sprintf "%s_%d" name arity
 
-  let private jsModuleNameToOCamlName (selfModuleName: string) (jsModuleName: string) =
+  let private jsModuleNameToOCamlName (jsModuleName: string) =
     match jsModuleName |> String.splitThenRemoveEmptyEntries "/" |> Array.toList with
-    | "." :: [] -> selfModuleName
-    | "." :: relativePath -> List.last relativePath
     | xs ->
       xs
       |> List.map (fun n ->
         n |> Naming.toCase Naming.Case.LowerSnakeCase)
       |> String.concat "__"
 
-  let jsModuleNameToFileName (selfModuleName: string) (jsModuleName: string) =
+  let jsModuleNameToFileName (jsModuleName: string) =
     jsModuleName
-    |> jsModuleNameToOCamlName selfModuleName
+    |> jsModuleNameToOCamlName
     |> sprintf "%s.mli"
 
-  let jsModuleNameToOCamlModuleName (selfModuleName: string) (jsModuleName: string) =
+  let jsModuleNameToOCamlModuleName (jsModuleName: string) =
     jsModuleName
-    |> jsModuleNameToOCamlName selfModuleName
+    |> jsModuleNameToOCamlName
     |> moduleName

--- a/src/Targets/JsOfOCaml/OCamlHelper.fs
+++ b/src/Targets/JsOfOCaml/OCamlHelper.fs
@@ -366,18 +366,22 @@ module Naming =
       else sprintf "%s_%d" name arity
     | None -> sprintf "%s_%d" name arity
 
-  let jsModuleNameToFileName (jsModuleName: string) =
+  let private jsModuleNameToOCamlName (selfModuleName: string) (jsModuleName: string) =
+    match jsModuleName |> String.splitThenRemoveEmptyEntries "/" |> Array.toList with
+    | "." :: [] -> selfModuleName
+    | "." :: relativePath -> List.last relativePath
+    | xs ->
+      xs
+      |> List.map (fun n ->
+        n |> Naming.toCase Naming.Case.LowerSnakeCase)
+      |> String.concat "__"
+
+  let jsModuleNameToFileName (selfModuleName: string) (jsModuleName: string) =
     jsModuleName
-    |> String.split "/"
-    |> Array.map (fun n ->
-      n |> Naming.toCase Naming.Case.LowerSnakeCase)
-    |> String.concat "__"
+    |> jsModuleNameToOCamlName selfModuleName
     |> sprintf "%s.mli"
 
-  let jsModuleNameToOCamlModuleName (jsModuleName: string) =
+  let jsModuleNameToOCamlModuleName (selfModuleName: string) (jsModuleName: string) =
     jsModuleName
-    |> String.split "/"
-    |> Array.map (fun n ->
-      n |> Naming.toCase Naming.Case.LowerSnakeCase)
-    |> String.concat "__"
+    |> jsModuleNameToOCamlName selfModuleName
     |> moduleName

--- a/src/Targets/JsOfOCaml/OCamlHelper.fs
+++ b/src/Targets/JsOfOCaml/OCamlHelper.fs
@@ -367,7 +367,7 @@ module Naming =
     | None -> sprintf "%s_%d" name arity
 
   let private jsModuleNameToOCamlName (jsModuleName: string) =
-    match jsModuleName |> String.splitThenRemoveEmptyEntries "/" |> Array.toList with
+    match jsModuleName.TrimStart('@') |> String.splitThenRemoveEmptyEntries "/" |> Array.toList with
     | xs ->
       xs
       |> List.map (fun n ->

--- a/src/Targets/JsOfOCaml/Target.fs
+++ b/src/Targets/JsOfOCaml/Target.fs
@@ -11,7 +11,7 @@ open Fable.Core.JsInterop
 let private builder (argv: Yargs.Argv<Options>) : Yargs.Argv<Options> =
   argv |> Options.register
 
-let private run (srcs: SourceFile list) (options: Options) =
+let private run (input: Input) (options: Options) =
   let outputDir =
     let curdir = Node.Api.``process``.cwd()
     match options.outputDir with
@@ -30,13 +30,13 @@ let private run (srcs: SourceFile list) (options: Options) =
     if options.createMinimalStdlib then
       [{ fileName = "ts2ocaml_min.mli"; content = Text.str stdlib; stubLines = [] }]
     else
-      if List.isEmpty srcs then
+      if List.isEmpty input.sources then
         Log.warnf options "No input file given."
         []
       else if options.stdlib then
-        emitStdlib srcs options
+        emitStdlib input options
       else
-        emitEverythingCombined srcs options
+        emitEverythingCombined input options
 
   for result in results do
     let fullPath = Node.Api.path.join[|outputDir; result.fileName|]

--- a/src/Targets/ParserTest.fs
+++ b/src/Targets/ParserTest.fs
@@ -11,17 +11,17 @@ type Options =
 let private builder (argv: Yargs.Argv<Options>) : Yargs.Argv<Options> =
   argv.addFlag("typing", (fun (o: Options) -> o.typing), descr="Apply typer")
 
-let private run (srcs: SourceFile list) (options: Options) =
+let private run (input: Input) (options: Options) =
   let srcs =
     if options.typing then
-      Typer.runAll srcs options |> snd
+      Typer.runAll input.sources options |> snd
     else
-      srcs
-  for src in srcs do
-    printfn "source: %s" src.fileName
-    for stmt in src.statements do
-      printfn "%A" stmt
-    printfn ""
+      input.sources
+  let moduleName =
+    JsHelper.deriveModuleName input.info (srcs |> List.map (fun src -> src.fileName))
+  printfn "package info: %A" (JS.stringify input.info)
+  printfn "sources: %A" (srcs |> List.map (fun src -> src.fileName))
+  printfn "derived module name: %A" moduleName
 
 let target =
   { new ITarget<Options> with

--- a/src/ts2ocaml.fsproj
+++ b/src/ts2ocaml.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="Common.fs" />
     <Compile Include="Syntax.fs" />
     <Compile Include="Naming.fs" />
+    <Compile Include="JsHelper.fs" />
     <Compile Include="Typer.fs" />
     <Compile Include="Parser.fs" />
     <Compile Include="Target.fs" />

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,6 @@ fs.readdirSync(nodeModulesDir)
   });
 
 module.exports = {
-  mode: 'production',
   target: "node",
   entry: CONFIG.fsharpEntry,
   externals: nodeExternals,


### PR DESCRIPTION
Closes #33.

Fixes a bug when processing relative imports.

This also adds heuristic `open/module` statements for relative imports. It will emit if the name matches one of the unknown types.

```ocaml
(* import { auth } from './lib/auth'; *)
[@@@js.stop] module Auth = Cassandra_driver__auth.Export.Auth  [@@@js.start] [@@@js.implem module Auth = Cassandra_driver__auth.Export.Auth ]

(* import { policies } from './lib/policies'; *)
[@@@js.stop] module Policies = Cassandra_driver__policies.Export.Policies  [@@@js.start] [@@@js.implem module Policies = Cassandra_driver__policies.Export.Policies ]

(* import { types } from './lib/types'; *)
[@@@js.stop] module Types = Cassandra_driver__types.Export.Types  [@@@js.start] [@@@js.implem module Types = Cassandra_driver__types.Export.Types ]

(* import { metrics } from './lib/metrics'; *)
[@@@js.stop] module Metrics = Cassandra_driver__metrics.Export.Metrics  [@@@js.start] [@@@js.implem module Metrics = Cassandra_driver__metrics.Export.Metrics ]

(* import { tracker } from './lib/tracker'; *)
[@@@js.stop] module Tracker = Cassandra_driver__tracker.Export.Tracker  [@@@js.start] [@@@js.implem module Tracker = Cassandra_driver__tracker.Export.Tracker ]

(* import { metadata } from './lib/metadata'; *)
[@@@js.stop] module Metadata = Cassandra_driver__metadata.Export.Metadata  [@@@js.start] [@@@js.implem module Metadata = Cassandra_driver__metadata.Export.Metadata ]
```