### PR TITLE
Follow relative references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add an option `--merge` to merge the input definition files to one binding.
+  - This is a breaking change; previously `--merge` was the default behavior.
+- Add an option `--follow-relative-references` to generate bindings for relevant files at once.
 
 ## [1.1.0] - 2021-11-24
 - Upgrade and fixed TypeScript version to >= 4.5.2 < 4.6.0.

--- a/build.fsx
+++ b/build.fsx
@@ -123,22 +123,25 @@ module Test =
 
       let packages = [
          // "full" package involving a lot of inheritance
-         "full", !! "node_modules/typescript/lib/typescript.d.ts";
+         "full", !! "node_modules/typescript/lib/typescript.d.ts", [];
 
          // "full" packages involving a lot of dependencies (which includes some "safe" packages)
-         "safe", !! "node_modules/@types/scheduler/tracing.d.ts";
-         "full", !! "node_modules/csstype/index.d.ts";
-         "safe", !! "node_modules/@types/prop-types/index.d.ts";
-         "full", !! "node_modules/@types/react/index.d.ts" ++ "node_modules/@types/react/global.d.ts";
-         "full", !! "node_modules/@types/react-modal/index.d.ts";
+         "safe", !! "node_modules/@types/scheduler/tracing.d.ts", [];
+         "full", !! "node_modules/csstype/index.d.ts", [];
+         "safe", !! "node_modules/@types/prop-types/index.d.ts", [];
+         "full", !! "node_modules/@types/react/index.d.ts" ++ "node_modules/@types/react/global.d.ts", [];
+         "full", !! "node_modules/@types/react-modal/index.d.ts", [];
 
          // "safe" package which depends on another "safe" package
-         "safe", !! "node_modules/@types/yargs-parser/index.d.ts";
-         "safe", !! "node_modules/@types/yargs/index.d.ts";
+         "safe", !! "node_modules/@types/yargs-parser/index.d.ts", [];
+         "safe", !! "node_modules/@types/yargs/index.d.ts", [];
       ]
 
-      for preset, package in packages do
-        ts2ocaml ["jsoo"; "--verbose"; "--nowarn"; "--follow-relative-references"; $"--preset {preset}"; $"-o {outputDir}"] package
+      for preset, package, additionalOptions in packages do
+        ts2ocaml
+          (["jsoo"; "--verbose"; "--nowarn"; "--follow-relative-references";
+            $"--preset {preset}"; $"-o {outputDir}"] @ additionalOptions)
+          package
 
     let build () =
       for file in outputDir |> Shell.copyRecursiveTo true srcDir do

--- a/build.fsx
+++ b/build.fsx
@@ -138,7 +138,7 @@ module Test =
       ]
 
       for preset, package in packages do
-        ts2ocaml ["jsoo"; "--verbose"; "--nowarn"; $"--preset {preset}"; $"-o {outputDir}"] package
+        ts2ocaml ["jsoo"; "--verbose"; "--nowarn"; "--follow-relative-references"; $"--preset {preset}"; $"-o {outputDir}"] package
 
     let build () =
       for file in outputDir |> Shell.copyRecursiveTo true srcDir do

--- a/docs/common_options.md
+++ b/docs/common_options.md
@@ -15,6 +15,28 @@ You should use `camelCase` key names. For example, if you want to set `--output-
 }
 ```
 
+## Parser Options
+
+### `--follow-relative-references`
+
+Follow and parse relative imports and file references.
+
+If this option is enabled, ts2ocaml tries to find relative `import` statements or `/// <referench path="...">` directives, and add the referenced files to the input files. ts2ocaml repeats this until no new file is added.
+
+> ts2ocaml will not follow package `import` statements and `/// <reference types="...">` directives.
+
+## Output Options
+
+### `--merge`
+
+Merge multiple input definition files to one binding.
+
+By default, ts2ocaml generates multiple bindings if multiple inputs are given.
+
+If this option is enabled, ts2ocaml bundles all the input files and generates one single binding.
+
+> This option may break relative imports. Use it with care.
+
 ## Logging Options
 
 ### `--verbose`

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/semver": "^7.3.6",
     "@types/yargs": "^17.0.0",
     "monaco-editor": "^0.24.0",
+    "react-player": "^2.9.0",
     "webpack": "^5.53.0",
     "webpack-cli": "^4.8.0",
     "webpack-dev-server": "^4.2.1"

--- a/src/Common.fs
+++ b/src/Common.fs
@@ -15,7 +15,7 @@ module GlobalOptions =
       .group(!^ResizeArray["config"], "General Options:")
       .describe(!^"config", "Specify the path to a ts2ocaml configuration JSON file.")
       .group(!^ResizeArray["follow-relative-references"], "Parser Options:")
-      .addFlag("follow-relative-references", (fun (o: GlobalOptions) -> o.followRelativeReferences), descr="Follow and parse relative imports and file references")
+      .addFlag("follow-relative-references", (fun (o: GlobalOptions) -> o.followRelativeReferences), descr="Follow and parse relative imports and file references.")
       .group(!^ResizeArray["merge"], "Output Options:")
       .addFlag("merge", (fun (o: GlobalOptions) -> o.merge), descr="Merge multiple input definition files to one binding", defaultValue=false)
       .group(!^ResizeArray["verbose"; "nowarn"], "Logging Options:")

--- a/src/Common.fs
+++ b/src/Common.fs
@@ -4,20 +4,24 @@ module Common
 type GlobalOptions =
   abstract verbose: bool with get
   abstract nowarn: bool with get
-  abstract followRelativeReferences: bool with get
+  abstract merge: bool with get, set
+  abstract followRelativeReferences: bool with get, set
 
 module GlobalOptions =
   open Fable.Core.JsInterop
 
   let register (yargs: Yargs.Argv<_>) =
     yargs
+      .group(!^ResizeArray["config"], "General Options:")
+      .describe(!^"config", "Specify the path to a ts2ocaml configuration JSON file.")
       .group(!^ResizeArray["follow-relative-references"], "Parser Options:")
       .addFlag("follow-relative-references", (fun (o: GlobalOptions) -> o.followRelativeReferences), descr="Follow and parse relative imports and file references")
+      .group(!^ResizeArray["merge"], "Output Options:")
+      .addFlag("merge", (fun (o: GlobalOptions) -> o.merge), descr="Merge multiple input definition files to one binding", defaultValue=false)
       .group(!^ResizeArray["verbose"; "nowarn"], "Logging Options:")
       .addFlag("verbose", (fun (o: GlobalOptions) -> o.verbose), descr="Show verbose log")
       .addFlag("nowarn", (fun (o: GlobalOptions) -> o.nowarn), descr="Do not show warnings")
-      .group(!^ResizeArray["config"], "General Options:")
-      .describe(!^"config", "Specify the path to a ts2ocaml configuration JSON file.")
+
 
 module Log =
   let tracef (opt: 'Options) fmt : _ when 'Options :> GlobalOptions =

--- a/src/Common.fs
+++ b/src/Common.fs
@@ -4,21 +4,19 @@ module Common
 type GlobalOptions =
   abstract verbose: bool with get
   abstract nowarn: bool with get
+  abstract followRelativeReferences: bool with get
 
 module GlobalOptions =
   open Fable.Core.JsInterop
 
   let register (yargs: Yargs.Argv<_>) =
     yargs
+      .group(!^ResizeArray["follow-relative-references"], "Parser Options:")
+      .addFlag("follow-relative-references", (fun (o: GlobalOptions) -> o.followRelativeReferences), descr="Follow and parse relative imports and file references")
       .group(!^ResizeArray["verbose"; "nowarn"], "Logging Options:")
       .addFlag("verbose", (fun (o: GlobalOptions) -> o.verbose), descr="Show verbose log")
       .addFlag("nowarn", (fun (o: GlobalOptions) -> o.nowarn), descr="Do not show warnings")
-      .group(
-        !^ResizeArray[
-          "config"
-        ],
-        "General Options:"
-      )
+      .group(!^ResizeArray["config"], "General Options:")
       .describe(!^"config", "Specify the path to a ts2ocaml configuration JSON file.")
 
 module Log =

--- a/src/Extensions.fs
+++ b/src/Extensions.fs
@@ -141,6 +141,15 @@ module Path =
       else Node.path.dirname(fromPath)
     Node.path.relative(fromPath, toPath)
 
+  let dirname (path: string) : string =
+    Node.path.dirname(path)
+
+  let join (paths: string list) : string =
+    Node.path.join(Array.ofList paths)
+
+  let separator =
+    Node.path.sep
+
 open Yargs
 
 type Argv<'T> with

--- a/src/JsHelper.fs
+++ b/src/JsHelper.fs
@@ -7,7 +7,7 @@ module Node = Node.Api
 let getPackageJsonPath (exampleFilePath: string) =
   let parts =
     exampleFilePath
-    |> String.split Node.path.sep
+    |> String.split Path.separator
     |> List.ofArray
   match parts |> List.tryFindIndexBack ((=) "node_modules") with
   | None -> None
@@ -21,11 +21,10 @@ let getPackageJsonPath (exampleFilePath: string) =
         | packageName :: _ -> [packageName]
         | _ -> failwith "impossible_getPackageJsonPath_root"
       let path =
-        prefix @ packageName @ ["package.json"] |> String.concat Node.path.sep
+        prefix @ packageName @ ["package.json"] |> String.concat Path.separator
 
       if not <| Node.fs.existsSync(!^path) then None
-      else if Node.path.isAbsolute(path) then Some path
-      else Some (Node.path.resolve(path))
+      else Some (Path.absolute path)
 
 type IPackageExportItem =
   [<EmitIndexer>]
@@ -48,7 +47,7 @@ let getPackageInfo (exampleFilePath: string) : Syntax.PackageInfo option =
   | Some path ->
     let p = getPackageJson path
 
-    let rootPath = Node.path.dirname(path)
+    let rootPath = Path.dirname path
 
     let name =
       if p.name.StartsWith("@types/") then
@@ -73,20 +72,20 @@ let getPackageInfo (exampleFilePath: string) : Syntax.PackageInfo option =
     let indexFile =
       match Option.orElse p.types p.typings, exports |> List.tryFind (fst >> (=) ".") with
       | None, None ->
-        let index = Node.path.join(rootPath, "index.d.ts")
+        let index = Path.join [rootPath; "index.d.ts"]
         if not <| Node.fs.existsSync(!^index) then None
         else
-          Node.path.relative(Node.``process``.cwd(), index) |> Node.path.normalize |> Some
+          Path.relative index |> Node.path.normalize |> Some
       | Some typings, _
       | None, Some (_, typings) ->
-        Node.path.relative(Node.``process``.cwd(), Node.path.join(rootPath, typings)) |> Node.path.normalize |> Some
+        Path.join [rootPath; typings] |> Path.relative |> Node.path.normalize |> Some
 
     let exports =
       exports
       |> List.filter (fst >> (<>) ".")
       |> List.map (fun (k, v) ->
         {| submodule = k;
-           file = Node.path.relative(Node.``process``.cwd(), Node.path.join(rootPath, v)) |> Node.path.normalize |})
+           file = Path.join [rootPath; v] |> Path.relative |> Node.path.normalize |})
 
     Some {
       name = name
@@ -143,17 +142,17 @@ let getJsModuleName (info: Syntax.PackageInfo option) (sourceFile: Path.Relative
       // make it relative to the package root directory
       let relativePath = Path.diff info.rootPath (Path.absolute sourceFile)
       if info.isDefinitelyTyped then
-        Node.path.join(info.name, stripExtension relativePath) |> Valid
+        Path.join [info.name; stripExtension relativePath] |> Valid
       else
         match info.exports |> List.tryFind (fun x -> x.file = sourceFile) with
-        | Some export -> Node.path.join(info.name, export.submodule) |> Valid
+        | Some export -> Path.join [info.name; export.submodule] |> Valid
         | None -> // heuristic
           let submodule =
             relativePath
             |> String.splitThenRemoveEmptyEntries "/"
             |> List.ofArray
             |> getSubmodule
-          Node.path.join(info.name, submodule) |> Heuristic
+          Path.join [info.name; submodule] |> Heuristic
   | None ->
     match inferPackageInfoFromFileName sourceFile with
     | None -> Unknown
@@ -178,13 +177,21 @@ let deriveModuleName (info: Syntax.PackageInfo option) (srcs: Path.Relative list
   | [] -> failwith "impossible_deriveModuleName"
   | [src] -> getJsModuleName info src
   | srcs ->
-    let names =
-      srcs
-      |> List.choose inferPackageInfoFromFileName
-      |> List.map (fun info -> info.name)
-      |> List.groupBy id
-      |> List.map (fun (name, xs) -> name, List.length xs)
-    names |> List.maxBy (fun (_, count) -> count) |> fst |> Heuristic
+    let fallback () =
+      let names =
+        srcs
+        |> List.choose inferPackageInfoFromFileName
+        |> List.map (fun info -> info.name)
+        |> List.groupBy id
+        |> List.map (fun (name, xs) -> name, List.length xs)
+      names |> List.maxBy (fun (_, count) -> count) |> fst |> Heuristic
+    match info with
+    | None -> fallback ()
+    | Some info ->
+      if info.indexFile |> Option.exists (fun index -> srcs |> List.exists ((=) index)) then
+        Valid info.name
+      else
+        fallback ()
 
 let deriveOutputFileName
   (opts: #GlobalOptions) (info: Syntax.PackageInfo option) (srcs: Path.Relative list)
@@ -202,8 +209,8 @@ let deriveOutputFileName
 let resolveRelativeImportPath (info: Syntax.PackageInfo option) (currentFile: Path.Relative) (path: string) =
   if path.StartsWith(".") then
     let targetPath =
-      let path = Node.path.join(Node.path.dirname(currentFile), path)
-      if not <| path.EndsWith(".ts") then Node.path.join(path, "index.d.ts")
+      let path = Path.join [Path.dirname currentFile; path]
+      if not <| path.EndsWith(".ts") then Path.join [path; "index.d.ts"]
       else path
     getJsModuleName info targetPath
   else

--- a/src/JsHelper.fs
+++ b/src/JsHelper.fs
@@ -105,6 +105,9 @@ module InferenceResult =
   let unwrap defaultValue = function
     | Valid s | Heuristic s -> s
     | Unknown -> defaultValue
+  let tryUnwrap = function
+    | Valid s | Heuristic s -> Some s
+    | Unknown -> None
 
 let inferPackageInfoFromFileName (sourceFile: Path.Relative) : {| name: string; isDefinitelyTyped: bool; rest: string list |} option =
   let parts =

--- a/src/Main.fs
+++ b/src/Main.fs
@@ -114,7 +114,7 @@ let getAllLocalReferences (opts: GlobalOptions) (sourceFiles: Ts.SourceFile seq)
 
   for sourceFile in sourceFiles do goSourceFile sourceFile
 
-  sourceFilesMap |> Seq.toArray |> Array.map (function KeyValue(k, v) -> Path.relative k, v) |> Array.unzip
+  sourceFilesMap.Values |> Seq.toArray |> Array.map (fun v -> v.fileName, v) |> Array.unzip
 
 let parse (opts: GlobalOptions) (argv: string[]) : Input =
   let program =
@@ -146,7 +146,7 @@ let parse (opts: GlobalOptions) (argv: string[]) : Input =
         ] |> Seq.toList
       let statements =
         src.statements
-        |> Seq.collect (Parser.readStatement !!{| verbose = opts.verbose; checker = checker; sourceFile = src; nowarn = opts.nowarn; followRelativeReferences = false |})
+        |> Seq.collect (Parser.readStatement !!{| verbose = opts.verbose; checker = checker; sourceFile = src; nowarn = opts.nowarn; followRelativeReferences = false; merge = false |})
         |> Seq.toList
       { statements = statements
         fileName = Path.relative src.fileName

--- a/src/Parser.fs
+++ b/src/Parser.fs
@@ -639,7 +639,7 @@ let readEnumCase (ctx: ParserContext) (em: Ts.EnumMember) : EnumCase option =
       | Some ep ->
         match readLiteral ep with
         | Some ((LInt _ | LString _) as l) -> Some l
-        | _ -> nodeError ep "enum value '%s' for case '%s' not supported" (ep.getText()) name
+        | _ -> nodeWarn ctx ep "enum value '%s' for case '%s' not supported" (ep.getText()) name; None
     let comments = readCommentsForNamedDeclaration ctx em
     Some { comments = comments; loc = Node.location em; name = name; value = value }
   | None -> nodeWarn ctx em "unsupported enum case name '%s'" (getText em.name); None
@@ -809,7 +809,6 @@ let readImportDeclaration (ctx: ParserContext) (i: Ts.ImportDeclaration) : State
         nodeWarn ctx i "invalid import statement"; None
     | kind ->
       nodeWarn ctx i "invalid kind '%s' for module specifier" (Enum.pp kind); None
-
 
 let readJSDocImpl (ctx: ParserContext) (doc: Ts.JSDoc) : Comment list =
   let desc =

--- a/src/Parser.fs
+++ b/src/Parser.fs
@@ -788,11 +788,11 @@ let readImportDeclaration (ctx: ParserContext) (i: Ts.ImportDeclaration) : State
       match c.name, c.namedBindings with
       | None, None -> create ES6WildcardImport
       | None, Some b when (!!b : Ts.Node).kind = Kind.NamespaceImport ->
-        let n = (!!c.namedBindings : Ts.NamespaceImport)
+        let n = (!!b : Ts.NamespaceImport)
         let kind = getKindFromIdentifier ctx n.name
         create (NamespaceImport {| name = n.name.text; kind = kind; isES6Import = true |})
       | _, Some b when (!!b : Ts.Node).kind = Kind.NamedImports ->
-        let n = (!!c.namedBindings : Ts.NamedImports)
+        let n = (!!b : Ts.NamedImports)
         let defaultImport = c.name |> Option.map (fun i -> {| name = i.text; kind = getKindFromIdentifier ctx i |})
         let bindings =
           n.elements
@@ -805,6 +805,9 @@ let readImportDeclaration (ctx: ParserContext) (i: Ts.ImportDeclaration) : State
               | None -> e.name.text, None
             {| name = name; kind = kind; renameAs = renameAs |})
         create (ES6Import {| defaultImport = defaultImport; bindings = bindings |})
+      | Some i, None ->
+        let defaultImport = {| name = i.text; kind = getKindFromIdentifier ctx i |}
+        create (ES6Import {| defaultImport = Some defaultImport; bindings = [] |})
       | _, _ ->
         nodeWarn ctx i "invalid import statement"; None
     | kind ->

--- a/src/Targets/JsOfOCaml/Common.fs
+++ b/src/Targets/JsOfOCaml/Common.fs
@@ -170,7 +170,7 @@ module Options =
         (fun (o: Options) -> o.preset),
         descr="Specify the preset to use."
       )
-
+      .group(!^ResizeArray[], "Parser Options:")
       .group(
         !^ResizeArray[
           "output-dir"; "stub-file"

--- a/src/Targets/JsOfOCaml/Writer.fs
+++ b/src/Targets/JsOfOCaml/Writer.fs
@@ -904,10 +904,9 @@ let emitClass flags overrideFunc (ctx: Context) (current: StructuredText) (c: Cl
     let scoped =
       let scoped = forceScoped |> Option.defaultValue Scoped.No
       let shouldBeScoped =
-        not c.isInterface // class generates global value
-        || c.members |> List.exists (fun (ma, m) ->
-             if ma.isStatic then true
-             else match m with Constructor _ -> true | _ -> false) // constructor generates global value
+        c.members |> List.exists (fun (ma, m) ->
+          if ma.isStatic then true
+          else match m with Constructor _ -> true | _ -> false) // constructor generates global value
       Scoped.union
         scoped
         (if shouldBeScoped then Scoped.Yes else Scoped.No)
@@ -1001,7 +1000,7 @@ let emitClass flags overrideFunc (ctx: Context) (current: StructuredText) (c: Cl
     | None -> None
     | Some name ->
       let kind =
-        if node.scoped <> Scoped.No then [Kind.Type; Kind.ClassLike; Kind.Value]
+        if not c.isInterface || node.scoped <> Scoped.No then [Kind.Type; Kind.ClassLike; Kind.Value]
         else [Kind.Type; Kind.ClassLike]
       getExportFromStatement ctx name kind (if c.isInterface then "interface" else "class") (ClassDef c)
   current

--- a/src/Targets/JsOfOCaml/Writer.fs
+++ b/src/Targets/JsOfOCaml/Writer.fs
@@ -12,13 +12,15 @@ open Targets.JsOfOCaml.OCamlHelper
 type ScriptTarget = TypeScript.Ts.ScriptTarget
 
 type State = {|
+  fileNames: string list
   info: Result<PackageInfo, string option>
   referencesCache: MutableMap<string list, WeakTrie<string>>
   usedAnonymousInterfacesCache: MutableMap<string list, Set<int>>
 |}
 module State =
-  let create info : State =
-    {| info = info
+  let create fileNames info : State =
+    {| fileNames = fileNames
+       info = info
        referencesCache = new MutableMap<_, _>();
        usedAnonymousInterfacesCache = new MutableMap<_, _>() |}
 
@@ -1494,7 +1496,7 @@ let emitStdlib (input: Input) (opts: Options) : Output list =
 
   let writerCtx ctx =
     ctx |> Context.mapOptions (fun _ -> opts)
-        |> Context.mapState (fun _ -> State.create (Error None))
+        |> Context.mapState (fun _ -> State.create [] (Error None))
 
   Log.tracef opts "* emitting stdlib..."
 
@@ -1518,49 +1520,59 @@ let emitStdlib (input: Input) (opts: Options) : Output list =
 
 let emitImports (ctx: Context) (sourceFile: SourceFile) : text list =
   let emitImport (i: Import) =
-    let moduleSpecifier =
-      match JsHelper.resolveRelativeImportPath (ctx.state.info |> Result.toOption) sourceFile.fileName i.moduleSpecifier with
-      | JsHelper.Valid s | JsHelper.Heuristic s -> s
-      | JsHelper.Unknown -> i.moduleSpecifier
-    let theirModuleName = moduleSpecifier |> Naming.jsModuleNameToOCamlModuleName
-
-    let isModule (name: string) (kind: Set<Kind> option) =
-      i.isTypeOnly
-      || kind |> Option.map (fun k -> Set.intersect k (Set.ofList [Kind.Type; Kind.ClassLike; Kind.Module]) |> Set.isEmpty |> not)
-              |> Option.defaultValue false
-      || ctx.unknownIdentTypes |> Trie.containsKey [name]
-      || name |> Naming.isCase Naming.PascalCase
-
-    let emitES6Import (b: {| name: string; kind: Set<Kind> option; renameAs: string option |}) =
-      if isModule b.name b.kind then
-        let theirName = b.name |> Naming.moduleName
-        let ourName =
-          match b.renameAs with
-          | Some name -> name |> Naming.moduleName
-          | None -> theirName
-        tprintf "module %s = %s.Export.%s " ourName theirModuleName theirName |> Some
+    // if the imported file is included in the input files, skip emitting it
+    let shouldBeSkipped =
+      if i.moduleSpecifier.StartsWith(".") |> not then false
       else
-        None
+        let relativePath = Path.join [Path.dirname sourceFile.fileName; i.moduleSpecifier]
+        let test path = ctx.state.fileNames |> List.contains path
+        test (relativePath + ".d.ts") || test (Path.join [relativePath; "index.d.ts"])
 
-    let stopStartImplem text =
-      Attr.js_stop_start_implem_oneliner text text
+    if shouldBeSkipped then []
+    else
+      let moduleSpecifier =
+        match JsHelper.resolveRelativeImportPath (ctx.state.info |> Result.toOption) sourceFile.fileName i.moduleSpecifier with
+        | JsHelper.Valid s | JsHelper.Heuristic s -> s
+        | JsHelper.Unknown -> i.moduleSpecifier
+      let theirModuleName = moduleSpecifier |> Naming.jsModuleNameToOCamlModuleName
 
-    [ yield empty
-      yield commentStr i.origText
-      match i.clause with
-      | ES6WildcardImport ->
-        yield open_ [ sprintf "%s.Export" theirModuleName ]
-      | NamespaceImport x ->
-        yield tprintf "module %s = %s.Export" (Naming.moduleName x.name) theirModuleName |> stopStartImplem
-      | ES6Import x ->
-        match x.defaultImport with
-        | None -> ()
-        | Some b ->
-          if isModule b.name b.kind then
-            let ourName = b.name |> Naming.moduleName
-            yield tprintf "module %s = %s.Export.Default" ourName theirModuleName |> stopStartImplem
-        for b in x.bindings do
-          match emitES6Import b with Some t -> yield stopStartImplem t | None -> () ]
+      let isModule (name: string) (kind: Set<Kind> option) =
+        i.isTypeOnly
+        || kind |> Option.map (fun k -> Set.intersect k (Set.ofList [Kind.Type; Kind.ClassLike; Kind.Module]) |> Set.isEmpty |> not)
+                |> Option.defaultValue false
+        || ctx.unknownIdentTypes |> Trie.containsKey [name]
+        || name |> Naming.isCase Naming.PascalCase
+
+      let emitES6Import (b: {| name: string; kind: Set<Kind> option; renameAs: string option |}) =
+        if isModule b.name b.kind then
+          let theirName = b.name |> Naming.moduleName
+          let ourName =
+            match b.renameAs with
+            | Some name -> name |> Naming.moduleName
+            | None -> theirName
+          tprintf "module %s = %s.Export.%s " ourName theirModuleName theirName |> Some
+        else
+          None
+
+      let stopStartImplem text =
+        Attr.js_stop_start_implem_oneliner text text
+
+      [ yield empty
+        yield commentStr i.origText
+        match i.clause with
+        | ES6WildcardImport ->
+          yield open_ [ sprintf "%s.Export" theirModuleName ]
+        | NamespaceImport x ->
+          yield tprintf "module %s = %s.Export" (Naming.moduleName x.name) theirModuleName |> stopStartImplem
+        | ES6Import x ->
+          match x.defaultImport with
+          | None -> ()
+          | Some b ->
+            if isModule b.name b.kind then
+              let ourName = b.name |> Naming.moduleName
+              yield tprintf "module %s = %s.Export.Default" ourName theirModuleName |> stopStartImplem
+          for b in x.bindings do
+            match emitES6Import b with Some t -> yield stopStartImplem t | None -> () ]
 
   sourceFile.statements |> List.collect (function Import i -> emitImport i | _ -> [])
 
@@ -1624,6 +1636,33 @@ let emitReferenceTypeDirectives (ctx: Context) (src: SourceFile) : text list =
       |> open_
     empty :: comments @ [openRefs]
 
+let emitReferenceFileDirectives (ctx: Context) (src: SourceFile) : text list =
+  let refs =
+    src.references
+    |> List.choose (function FileReference r -> Some r | _ -> None)
+  if List.isEmpty refs then []
+  else
+    // if the referenced file is included in the input files, skip emitting it
+    let validRefs =
+      refs
+      |> List.choose (fun ref ->
+        let relativePath = Path.join [Path.dirname src.fileName; ref]
+        if ctx.state.fileNames |> List.contains relativePath |> not then
+          Some {| path = ref; relativePath = relativePath |}
+        else None)
+    let comments =
+      refs
+      |> List.map (sprintf "<reference path=\"%s\">")
+      |> List.map commentStr
+    let openRefs =
+      validRefs
+      |> List.choose (fun x ->
+        JsHelper.deriveModuleName (Result.toOption ctx.state.info) [x.relativePath]
+        |> JsHelper.InferenceResult.tryUnwrap
+        |> Option.map Naming.jsModuleNameToOCamlModuleName)
+      |> open_
+    empty :: comments @ [openRefs]
+
 let private emitImpl (sources: SourceFile list) (info: PackageInfo option) (opts: Options) =
   let derivedOutputFileName =
     JsHelper.deriveOutputFileName
@@ -1643,7 +1682,7 @@ let private emitImpl (sources: SourceFile list) (info: PackageInfo option) (opts
   let ctx, srcs = runAll sources opts
   let ctx =
     ctx |> Context.mapOptions (fun _ -> opts)
-        |> Context.mapState (fun _ -> State.create info)
+        |> Context.mapState (fun _ -> State.create (srcs |> List.map (fun s -> s.fileName)) info)
   let stmts = srcs |> List.collect (fun x -> x.statements)
   let structuredText = createStructuredText ctx stmts
 
@@ -1662,6 +1701,7 @@ let private emitImpl (sources: SourceFile list) (info: PackageInfo option) (opts
       for src in srcs do
         yield! emitImports ctx src
         yield! emitReferenceTypeDirectives ctx src
+        yield! emitReferenceFileDirectives ctx src
 
       yield empty
       yield! emitStatementsWithStructuredText ctx stmts structuredText
@@ -1671,26 +1711,7 @@ let private emitImpl (sources: SourceFile list) (info: PackageInfo option) (opts
 
 let emit (input: Input) (opts: Options) : Output list =
   if opts.merge then
-    let srcs =
-      match input.sources with
-      | [] | _ :: [] -> input.sources
-      | srcs ->
-        let combinedName, moduleName =
-          match srcs |> List.tryFind (fun src -> src.fileName.EndsWith "index.d.ts") with
-          | Some index ->
-            Log.tracef opts "* using index.d.ts as an entrypoint"
-            index.fileName, index.moduleName
-          | None ->
-            Log.tracef opts "* treating everything as combined into lib.d.ts"
-            "lib.d.ts", None
-        [
-          { fileName = combinedName
-            statements = srcs |> List.collect (fun src -> src.statements)
-            references = srcs |> List.collect (fun src -> src.references) |> List.distinct
-            hasNoDefaultLib = srcs |> List.exists (fun src -> src.hasNoDefaultLib)
-            moduleName = moduleName }
-        ]
-    [emitImpl srcs input.info opts]
+    [emitImpl input.sources input.info opts]
   else
     input.sources
     |> List.map (fun source -> emitImpl [source] input.info opts)

--- a/src/Targets/JsOfOCaml/Writer.fs
+++ b/src/Targets/JsOfOCaml/Writer.fs
@@ -1608,14 +1608,12 @@ let emitReferenceTypeDirectives (ctx: Context) (src: SourceFile) : text list =
   let refs =
     src.references
     |> List.choose (function TypeReference r -> Some r | _ -> None)
-
   if List.isEmpty refs then []
   else
     let comments =
       refs
       |> List.map (sprintf "<reference types=\"%s\">")
       |> List.map commentStr
-
     let openRefs =
       refs
       |> List.map (fun x ->
@@ -1624,7 +1622,6 @@ let emitReferenceTypeDirectives (ctx: Context) (src: SourceFile) : text list =
         |> JsHelper.InferenceResult.unwrap x
         |> Naming.jsModuleNameToOCamlModuleName)
       |> open_
-
     empty :: comments @ [openRefs]
 
 let emitEverythingCombined (input: Input) (opts: Options) : Output list =

--- a/src/Targets/JsOfOCaml/Writer.fs
+++ b/src/Targets/JsOfOCaml/Writer.fs
@@ -1624,45 +1624,23 @@ let emitReferenceTypeDirectives (ctx: Context) (src: SourceFile) : text list =
       |> open_
     empty :: comments @ [openRefs]
 
-let emitEverythingCombined (input: Input) (opts: Options) : Output list =
-  let srcs = input.sources
-
-  let srcs =
-    match srcs with
-    | [] | _ :: [] -> srcs
-    | _ ->
-      let combinedName, moduleName =
-        match srcs |> List.tryFind (fun src -> src.fileName.EndsWith "index.d.ts") with
-        | Some index ->
-          Log.tracef opts "* using index.d.ts as an entrypoint"
-          index.fileName, index.moduleName
-        | None ->
-          Log.tracef opts "* treating everything as combined into lib.d.ts"
-          "lib.d.ts", None
-      [
-        { fileName = combinedName
-          statements = srcs |> List.collect (fun src -> src.statements)
-          references = srcs |> List.collect (fun src -> src.references) |> List.distinct
-          hasNoDefaultLib = srcs |> List.exists (fun src -> src.hasNoDefaultLib)
-          moduleName = moduleName }
-      ]
-
+let private emitImpl (sources: SourceFile list) (info: PackageInfo option) (opts: Options) =
   let derivedOutputFileName =
     JsHelper.deriveOutputFileName
-      opts input.info (srcs |> List.map (fun src -> src.fileName))
+      opts info (sources |> List.map (fun s -> s.fileName))
       Naming.jsModuleNameToFileName "output.mli"
 
   let derivedModuleName =
-    JsHelper.deriveModuleName input.info (srcs |> List.map (fun src -> src.fileName))
+    JsHelper.deriveModuleName info (sources |> List.map (fun s -> s.fileName))
     |> JsHelper.InferenceResult.unwrap "package"
 
   let info =
-    match input.info with
+    match info with
     | Some info -> Ok info
     | None -> Error (Some derivedModuleName)
 
   Log.tracef opts "* running typer..."
-  let ctx, srcs = runAll srcs opts
+  let ctx, srcs = runAll sources opts
   let ctx =
     ctx |> Context.mapOptions (fun _ -> opts)
         |> Context.mapState (fun _ -> State.create info)
@@ -1671,7 +1649,7 @@ let emitEverythingCombined (input: Input) (opts: Options) : Output list =
 
   let exported = handleExports derivedModuleName ctx structuredText
 
-  Log.tracef opts "* emitting a binding for js_of_ocaml..."
+  Log.tracef opts "* emitting a binding to '%s' for js_of_ocaml..." derivedModuleName
   let content =
     concat newline [
       yield! header
@@ -1689,4 +1667,30 @@ let emitEverythingCombined (input: Input) (opts: Options) : Output list =
       yield! emitStatementsWithStructuredText ctx stmts structuredText
     ]
 
-  [{ fileName = derivedOutputFileName; content = content; stubLines = exported.stubLines }]
+  { fileName = derivedOutputFileName; content = content; stubLines = exported.stubLines }
+
+let emit (input: Input) (opts: Options) : Output list =
+  if opts.merge then
+    let srcs =
+      match input.sources with
+      | [] | _ :: [] -> input.sources
+      | srcs ->
+        let combinedName, moduleName =
+          match srcs |> List.tryFind (fun src -> src.fileName.EndsWith "index.d.ts") with
+          | Some index ->
+            Log.tracef opts "* using index.d.ts as an entrypoint"
+            index.fileName, index.moduleName
+          | None ->
+            Log.tracef opts "* treating everything as combined into lib.d.ts"
+            "lib.d.ts", None
+        [
+          { fileName = combinedName
+            statements = srcs |> List.collect (fun src -> src.statements)
+            references = srcs |> List.collect (fun src -> src.references) |> List.distinct
+            hasNoDefaultLib = srcs |> List.exists (fun src -> src.hasNoDefaultLib)
+            moduleName = moduleName }
+        ]
+    [emitImpl srcs input.info opts]
+  else
+    input.sources
+    |> List.map (fun source -> emitImpl [source] input.info opts)

--- a/test/jsoo/src/dune
+++ b/test/jsoo/src/dune
@@ -55,6 +55,11 @@
   (action (run %{bin:gen_js_api} %{deps})))
 
 (rule
+  (targets react__global.ml)
+  (deps react__global.mli)
+  (action (run %{bin:gen_js_api} %{deps})))
+
+(rule
   (targets react.ml)
   (deps react.mli)
   (action (run %{bin:gen_js_api} %{deps})))

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,6 +865,11 @@ deep-equal@^1.0.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
+deepmerge@^4.0.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-gateway@^6.0.0:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-6.0.3.tgz#819494c888053bdb743edbf343d6cdf7f2943a71"
@@ -1580,7 +1585,7 @@ jest-worker@^27.0.6:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -1612,6 +1617,11 @@ kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
+
 loader-runner@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
@@ -1629,6 +1639,13 @@ lodash@^4.17.14:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -1640,6 +1657,11 @@ memfs@^3.2.2:
   integrity sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==
   dependencies:
     fs-monkey "1.0.3"
+
+memoize-one@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -1789,6 +1811,11 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-is@^1.0.1:
   version "1.1.5"
@@ -1964,6 +1991,15 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 proxy-addr@~2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -2018,6 +2054,27 @@ raw-body@2.4.0:
     http-errors "1.7.2"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-is@^16.8.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-player@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.9.0.tgz#ef7fe7073434087565f00ff219824e1e02c4b046"
+  integrity sha512-jNUkTfMmUhwPPAktAdIqiBcVUKsFKrVGH6Ocutj6535CNfM91yrvWxHg6fvIX8Y/fjYUPoejddwh7qboNV9vGA==
+  dependencies:
+    deepmerge "^4.0.0"
+    load-script "^1.0.0"
+    memoize-one "^5.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.0.1"
 
 readable-stream@^2.0.1:
   version "2.3.7"


### PR DESCRIPTION
- Add an option `--merge` to merge the input definition files to one binding.
  - This is a breaking change; previously `--merge` was the default behavior.
- Add an option `--follow-relative-references` to generate bindings for relevant files at once.
  - It will follow all the relative imports and [reference directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-path-) and load them at once.
