### PR TITLE
Use Node.js 16.x in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         dotnet:
           - 5.0.x
         node-version:
-          - 14.x
+          - 16.x
         ocaml-compiler:
           - 4.08.x
           - 4.09.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         dotnet:
           - 5.0.x
         node-version:
-          - 14.x
+          - 16.x
         ocaml-compiler:
           - 4.13.x
 


### PR DESCRIPTION
Note that Node.js `17.x` is actually released, but is not yet compatible with this project.