### PR TITLE
rescript: prefix invalid ctor names by 'Case'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ReScript: prefix invalid constructor names by `Case` (#392).
+
 ## [2.0.0-beta.2]
 
 - Update and fix TypeScript version to `5.3.3`.

--- a/src/Targets/ReScript/ReScriptHelper.fs
+++ b/src/Targets/ReScript/ReScriptHelper.fs
@@ -167,7 +167,7 @@ module Naming =
 
   let constructorName (name: string list) =
     let s = String.concat "_" name |> removeInvalidChars |> upperFirst
-    if s.StartsWith("_") then "C" + s
+    if Char.isAlphabet(s[0]) |> not then "Case" + s
     else if keywords |> Set.contains s then s + "_"
     else s
 


### PR DESCRIPTION
Fixes #392.

This PR modifies `ReScriptHelper.Naming.constructorName` so that it prefixes any kind of invalid constructor name (not starting with an alphabet) by `Case`.

```typescript
export type Test = "1" | "2";
```

```rescript
type t =
  | @as(1) Case1
  | @as(2) Case2
```